### PR TITLE
Add core Codex automation modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-# proof-codex-ai
+# Proof Codex AI
+
+This repository contains tools for managing the Proof Codex and related automation scripts.
+
+## Modules
+
+- `codex_task_parser.py` parses task log files and produces Codex entries such as `[LAW:]` or `[SYSTEM:]` blocks.
+- `codex_auto_updater.py` appends parsed entries to the master Codex document automatically.
+- `data_scraper.py` provides simple web scraping and search API helpers for gathering viewer psychology and Shorts algorithm information.
+- `codex_validator.py` validates entries to ensure they comply with basic Codex formatting rules.
+
+These utilities are meant to assist the Codex AI workflow.

--- a/codex/__init__.py
+++ b/codex/__init__.py
@@ -1,0 +1,14 @@
+"""Utility modules for managing the Proof Codex."""
+
+from .codex_task_parser import CodexTaskParser, CodexEntry
+from .codex_auto_updater import update_master_codex
+from .codex_validator import validate_entries
+from .data_scraper import DataScraper
+
+__all__ = [
+    "CodexTaskParser",
+    "CodexEntry",
+    "update_master_codex",
+    "validate_entries",
+    "DataScraper",
+]

--- a/codex/codex_auto_updater.py
+++ b/codex/codex_auto_updater.py
@@ -1,0 +1,22 @@
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable
+
+from .codex_task_parser import CodexTaskParser, CodexEntry
+
+
+def update_master_codex(master_codex_path: Path, log_dir: Path) -> None:
+    """Append new codex entries from task logs to the master codex file."""
+    parser = CodexTaskParser(log_dir)
+    entries = parser.parse_logs()
+    if not entries:
+        return
+
+    master_codex_path = Path(master_codex_path)
+    if not master_codex_path.exists():
+        master_codex_path.touch()
+
+    with master_codex_path.open("a") as f:
+        f.write(f"\n# Updated on {datetime.utcnow().isoformat()}\n")
+        for entry in entries:
+            f.write(f"[{entry.tag}:] {entry.content}\n")

--- a/codex/codex_task_parser.py
+++ b/codex/codex_task_parser.py
@@ -1,0 +1,50 @@
+from dataclasses import dataclass
+from pathlib import Path
+import json
+import re
+from typing import List, Iterable
+
+
+@dataclass
+class CodexEntry:
+    """Represents an entry extracted from a task log."""
+    tag: str
+    content: str
+
+
+class CodexTaskParser:
+    """Parses new task logs and converts them into codex entries."""
+
+    LOG_PATTERN = re.compile(r"\[(?P<tag>[A-Z]+):\]\s*(?P<content>.*)")
+
+    def __init__(self, log_dir: Path):
+        self.log_dir = Path(log_dir)
+        self.state_file = self.log_dir / "processed_logs.json"
+        if not self.log_dir.exists():
+            self.log_dir.mkdir(parents=True)
+        self.processed_files = set()
+        if self.state_file.exists():
+            try:
+                self.processed_files = set(json.loads(self.state_file.read_text()))
+            except Exception:
+                self.processed_files = set()
+
+    def _save_state(self) -> None:
+        self.state_file.write_text(json.dumps(list(self.processed_files)))
+
+    def parse_logs(self) -> List[CodexEntry]:
+        """Parse new logs in the directory and return codex entries."""
+        entries: List[CodexEntry] = []
+        for log_file in sorted(self.log_dir.glob("*.log")):
+            if log_file.name in self.processed_files:
+                continue
+            for line in log_file.read_text().splitlines():
+                match = self.LOG_PATTERN.match(line.strip())
+                if match:
+                    entries.append(
+                        CodexEntry(tag=match.group("tag"), content=match.group("content"))
+                    )
+            self.processed_files.add(log_file.name)
+        if entries:
+            self._save_state()
+        return entries

--- a/codex/codex_validator.py
+++ b/codex/codex_validator.py
@@ -1,0 +1,18 @@
+"""Validate codex entries against Proof Codex laws."""
+
+from pathlib import Path
+from typing import Iterable
+
+from .codex_task_parser import CodexEntry
+
+
+VALID_TAGS = {"LAW", "SYSTEM", "PROMPT", "PILLAR"}
+
+
+def validate_entries(entries: Iterable[CodexEntry]) -> None:
+    """Raise ValueError if any entry does not comply with Codex rules."""
+    for entry in entries:
+        if entry.tag not in VALID_TAGS:
+            raise ValueError(f"Invalid tag: {entry.tag}")
+        if not entry.content.strip():
+            raise ValueError("Entry content cannot be empty")

--- a/codex/data_scraper.py
+++ b/codex/data_scraper.py
@@ -1,0 +1,44 @@
+"""Web scraping and search API utilities for Codex AI."""
+
+import os
+from pathlib import Path
+from typing import List
+
+import requests
+from bs4 import BeautifulSoup
+
+
+class DataScraper:
+    """Simple scraper and search API wrapper."""
+
+    def __init__(self, data_dir: Path):
+        self.data_dir = Path(data_dir)
+        if not self.data_dir.exists():
+            self.data_dir.mkdir(parents=True)
+
+    def scrape_url(self, url: str) -> str:
+        """Download the contents of a URL and return text."""
+        resp = requests.get(url, timeout=10)
+        resp.raise_for_status()
+        soup = BeautifulSoup(resp.text, "html.parser")
+        text = soup.get_text(separator="\n")
+        file_path = self.data_dir / f"{Path(url).stem}.txt"
+        file_path.write_text(text)
+        return text
+
+    def search(self, query: str, api_key: str = None, engine_id: str = None) -> List[str]:
+        """Perform a web search using Google Custom Search API (if keys provided)."""
+        api_key = api_key or os.getenv("GOOGLE_API_KEY")
+        engine_id = engine_id or os.getenv("GOOGLE_ENGINE_ID")
+        if not api_key or not engine_id:
+            raise RuntimeError("Google API key and engine ID must be provided")
+        params = {
+            "key": api_key,
+            "cx": engine_id,
+            "q": query,
+        }
+        resp = requests.get("https://www.googleapis.com/customsearch/v1", params=params, timeout=10)
+        resp.raise_for_status()
+        data = resp.json()
+        results = [item["link"] for item in data.get("items", [])]
+        return results


### PR DESCRIPTION
## Summary
- add utilities under `codex/`
- implement `CodexTaskParser` for parsing `[LAW:]` and `[SYSTEM:]` entries
- implement `update_master_codex` to append parsed tasks
- provide `DataScraper` for web scraping and search API integration
- provide `validate_entries` for simple Codex law validation
- update README with module descriptions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6850c8358b6483339352fe0516ced588